### PR TITLE
Remove duplicate command output

### DIFF
--- a/lib/fastlane/plugin/rome/actions/rome_action.rb
+++ b/lib/fastlane/plugin/rome/actions/rome_action.rb
@@ -29,9 +29,7 @@ module Fastlane
         cmd << "--no-skip-current" if params[:noskipcurrent] == true
         cmd << "-v " if params[:verbose]
 
-        action = Actions.sh(cmd.join(' '))
-        UI.message(action)
-        return action
+        return Actions.sh(cmd.join(' '))
       end
 
       def self.meet_minimum_version(binary_path, minimum_version)

--- a/spec/rome_action_spec.rb
+++ b/spec/rome_action_spec.rb
@@ -2,9 +2,12 @@ describe Fastlane::Actions::RomeAction do
   describe '#run' do
     it 'calls the rome binary at the expected path' do
       path_to_rome_binary = `which rome`
-      expect(Fastlane::UI).to receive(:message).with("#{path_to_rome_binary.chomp} --version")
-      Fastlane::Actions::RomeAction.run({:binary_path => path_to_rome_binary, :command => "version"})
+      result = Fastlane::FastFile.new.parse("lane :test do
+        rome(command: 'version')
+      end").runner.execute(:test)
+      expect(result).to eq("#{path_to_rome_binary.chomp} --version")
     end
+
     it 'checks minimum version correctly' do
       expect(Fastlane::Actions::RomeAction.version_is_greater_or_equal("0.0.0.1", "")).to be true
       expect(Fastlane::Actions::RomeAction.version_is_greater_or_equal("0.0.0.0", "")).to be true


### PR DESCRIPTION
`Actions.sh` and `UI.message` both print the `rome` command output out to the console, which is a **lot** when you run a `download` or `upload` command. This patch removes the `UI.message` action.